### PR TITLE
Output config files with JSON dumps of Pydantic models

### DIFF
--- a/govuk_chat_evaluation/file_system.py
+++ b/govuk_chat_evaluation/file_system.py
@@ -68,7 +68,7 @@ def write_config_file_for_reuse(output_dir: Path, config: BaseConfig) -> Path:
     """Write a Config object as a YAML file in the output directory"""
     config_path = output_dir / "config.yaml"
     with open(config_path, "w", encoding="utf8") as file:
-        yaml.dump(dict(config), file, default_flow_style=False)
+        yaml.dump(config.model_dump(mode="json"), file, default_flow_style=False)
 
     relative_path = config_path.relative_to(project_root())
     print(f"Wrote used config to {relative_path}")

--- a/tests/test_file_system.py
+++ b/tests/test_file_system.py
@@ -20,6 +20,7 @@ from govuk_chat_evaluation.file_system import (
 
 class SampleConfig(BaseConfig):
     what: str
+    path: Path
 
 
 class SampleModel(BaseModel):
@@ -68,12 +69,12 @@ def test_write_generated_to_output(mock_project_root):
 
 
 def test_write_config_file_for_reuse(mock_project_root):
-    config = SampleConfig(what="Testing config")
+    config = SampleConfig(what="Testing config", path=Path("path/to/item"))
     config_path = write_config_file_for_reuse(mock_project_root, config)
     assert config_path.exists()
     with open(config_path, "r", encoding="utf-8") as file:
         content = yaml.safe_load(file)
-    assert content == {"what": "Testing config"}
+    assert content == {"what": "Testing config", "path": "path/to/item"}
 
 
 def test_write_csv_results(mock_project_root):


### PR DESCRIPTION
This corrects an issue where the generated config file was specifying a Path object and was thus quite significantly different from input.

Before:

```
$ cat results/jailbreak_guardrails/2025-04-24T10:45:23/config.yaml
generate: true
input_path: !!python/object/apply:pathlib._local.PosixPath
- data/jailbreak_guardrails.jsonl
provider: openai
what: Evaluating jailbreak guardrails
```

After:

```
$ cat results/jailbreak_guardrails/2025-04-24T10:46:16/config.yaml
generate: true
input_path: data/jailbreak_guardrails.jsonl
provider: openai
what: Evaluating jailbreak guardrails
```