### PR TITLE
Return generated answer in question router evaluation.

### DIFF
--- a/govuk_chat_evaluation/question_router/evaluate.py
+++ b/govuk_chat_evaluation/question_router/evaluate.py
@@ -25,6 +25,7 @@ class EvaluationResult(BaseModel):
     expected_outcome: str
     actual_outcome: str
     confidence_score: float
+    answer: str | None = None
 
     def for_csv(self) -> dict[str, Any]:
         return {**self.model_dump()}
@@ -97,6 +98,7 @@ class AggregateResults:
                 "predicted_classification": result.expected_outcome,
                 "actual_classification": result.actual_outcome,
                 "confidence_score": result.confidence_score,
+                "answer": result.answer,
             }
             for result in self.evaluation_results
             if result.expected_outcome != result.actual_outcome

--- a/govuk_chat_evaluation/question_router/generate.py
+++ b/govuk_chat_evaluation/question_router/generate.py
@@ -37,6 +37,7 @@ def generate_inputs_to_evaluation_results(
             expected_outcome=input.expected_outcome,
             actual_outcome=result["classification"],
             confidence_score=result["confidence_score"],
+            answer=result["answer"],
         )
 
     return asyncio.run(

--- a/tests/question_router/test_evaluate.py
+++ b/tests/question_router/test_evaluate.py
@@ -19,6 +19,7 @@ class TestEvaluationResult:
             expected_outcome="genuine_rag",
             actual_outcome="greetings",
             confidence_score=0.9,
+            answer=None,
         )
 
         assert result.for_csv() == {
@@ -26,6 +27,7 @@ class TestEvaluationResult:
             "expected_outcome": "genuine_rag",
             "actual_outcome": "greetings",
             "confidence_score": 0.9,
+            "answer": None,
         }
 
 
@@ -38,30 +40,35 @@ class TestAggregateResults:
                 expected_outcome="genuine_rag",
                 actual_outcome="genuine_rag",
                 confidence_score=0.95,
+                answer=None,
             ),
             EvaluationResult(
                 question="Q2",
                 expected_outcome="about_mps",
                 actual_outcome="about_mps",
                 confidence_score=0.9,
+                answer="This is an about mps answer",
             ),
             EvaluationResult(
                 question="Q3",
                 expected_outcome="character_fun",
                 actual_outcome="genuine_rag",
                 confidence_score=0.5,
+                answer="This is a character fun answer",
             ),
             EvaluationResult(
                 question="Q4",
                 expected_outcome="character_fun",
                 actual_outcome="about_mps",
                 confidence_score=0.3,
+                answer="This is a character fun answer",
             ),
             EvaluationResult(
                 question="Q5",
                 expected_outcome="genuine_rag",
                 actual_outcome="genuine_rag",
                 confidence_score=0.5,
+                answer=None,
             ),
         ]
 
@@ -104,12 +111,14 @@ class TestAggregateResults:
             "predicted_classification": "character_fun",
             "actual_classification": "genuine_rag",
             "confidence_score": 0.5,
+            "answer": "This is a character fun answer",
         }
         assert miscategorised[1] == {
             "question": "Q4",
             "predicted_classification": "character_fun",
             "actual_classification": "about_mps",
             "confidence_score": 0.3,
+            "answer": "This is a character fun answer",
         }
 
     def test_to_dict(self, sample_results):
@@ -141,12 +150,14 @@ def mock_evaluation_data_file(tmp_path):
             "expected_outcome": "genuine_rag",
             "actual_outcome": "genuine_rag",
             "confidence_score": 0.95,
+            "answer": None,
         },
         {
             "question": "Question 2",
             "expected_outcome": "genuine_rag",
             "actual_outcome": "about_mps",
             "confidence_score": 0.95,
+            "answer": "This is an about mps answer",
         },
     ]
 
@@ -212,6 +223,7 @@ def test_evaluate_and_output_results_writes_miscategorised_cases(
         assert "question" in headers
         assert "predicted_classification" in headers
         assert "actual_classification" in headers
+        assert "answer" in headers
 
 
 def test_evaluate_and_output_results_prints_aggregates(

--- a/tests/question_router/test_generate.py
+++ b/tests/question_router/test_generate.py
@@ -15,9 +15,17 @@ from govuk_chat_evaluation.question_router.generate import (
 def run_rake_task_mock(mocker):
     async def default_side_effect(_, env):
         if env["INPUT"] == "Question 1":
-            return {"classification": "genuine_rag", "confidence_score": 0.9}
+            return {
+                "classification": "genuine_rag",
+                "confidence_score": 0.9,
+                "answer": None,
+            }
         else:
-            return {"classification": "greetings", "confidence_score": 0.8}
+            return {
+                "classification": "greetings",
+                "confidence_score": 0.8,
+                "answer": "This is a greetings answer",
+            }
 
     mock = mocker.patch(
         "govuk_chat_evaluation.question_router.generate.run_rake_task",
@@ -46,12 +54,14 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
             expected_outcome="genuine_rag",
             actual_outcome="genuine_rag",
             confidence_score=0.9,
+            answer=None,
         ),
         EvaluationResult(
             question="Question 2",
             expected_outcome="greetings",
             actual_outcome="greetings",
             confidence_score=0.8,
+            answer="This is a greetings answer",
         ),
     ]
     actual_results = generate_inputs_to_evaluation_results("openai", generate_inputs)


### PR DESCRIPTION
Updated govuk_chat_evaluation/question_router/evaluate.py and generate.py to also return the generated answer when intent is not genuine_rag. This was needed to support downstream evaluation analysis of the question router's performance and behaviour.

Adjusted tests to capture these changes.