### PR TITLE
Make ideal_answer optional in EvaluationTestCase in rag_answers/data_models.py

### DIFF
--- a/govuk_chat_evaluation/rag_answers/data_models.py
+++ b/govuk_chat_evaluation/rag_answers/data_models.py
@@ -2,7 +2,7 @@ from deepeval.test_case import LLMTestCase
 from pydantic import BaseModel, model_validator
 from pydantic.dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 import uuid
 
 from deepeval.metrics import (
@@ -41,8 +41,7 @@ class StructuredContext(BaseModel):
 
 class GenerateInput(BaseModel):
     question: str
-    ideal_answer: str
-    # TODO: lots more data fields
+    ideal_answer: Optional[str] = None
 
 
 class EvaluationTestCase(GenerateInput):
@@ -173,6 +172,6 @@ class EvaluationResult:
     name: str
     input: str
     actual_output: str
-    expected_output: str
     retrieval_context: list[str]
     run_metric_outputs: list[RunMetricOutput]
+    expected_output: Optional[str] = None

--- a/tests/rag_answers/test_data_models.py
+++ b/tests/rag_answers/test_data_models.py
@@ -76,7 +76,9 @@ class TestConfig:
 
 
 class TestEvaluationTestCase:
-    def test_to_llm_test_case(self):
+    @pytest.mark.parametrize("ideal_answer", ["Great", None])
+    def test_to_llm_test_case(self, ideal_answer):
+        """Test EvaluationTestCase.to_llm_test_case with and without ideal_answer"""
         structured_context = StructuredContext(
             title="VAT",
             heading_hierarchy=["Tax", "VAT"],
@@ -88,7 +90,7 @@ class TestEvaluationTestCase:
 
         evaluation_test_case = EvaluationTestCase(
             question="How are you?",
-            ideal_answer="Great",
+            ideal_answer=ideal_answer,
             llm_answer="Fine",
             retrieved_context=[structured_context],
         )
@@ -96,11 +98,9 @@ class TestEvaluationTestCase:
         llm_test_case = evaluation_test_case.to_llm_test_case()
 
         assert isinstance(llm_test_case, LLMTestCase)
-        assert llm_test_case.input == evaluation_test_case.question
-        assert llm_test_case.expected_output == evaluation_test_case.ideal_answer
-        assert llm_test_case.actual_output == evaluation_test_case.llm_answer
-        assert llm_test_case.name is not None
         assert isinstance(llm_test_case.name, str)
+        assert llm_test_case.expected_output == ideal_answer
+        assert llm_test_case.actual_output == evaluation_test_case.llm_answer
 
         assert isinstance(llm_test_case.retrieval_context, list)
         assert all(isinstance(chunk, str) for chunk in llm_test_case.retrieval_context)


### PR DESCRIPTION
Updated EvaluationTestCase.ideal_answer to be optional (Optional[str]) so that certain metrics that do not require an ideal answer (faithfulness, relevancy) do not break the evaluation pipeline when computed in isolation for test cases for which we do not have an ideal answer.

This was needed during extensive evaluation pre-App integration.

Adapted tests to handle both cases when ideal_answer is provided or None.