### PR TITLE
Populate StructuredContext for rag_answers

### DIFF
--- a/govuk_chat_evaluation/rag_answers/data_models.py
+++ b/govuk_chat_evaluation/rag_answers/data_models.py
@@ -24,7 +24,7 @@ from ..config import BaseConfig
 class StructuredContext(BaseModel):
     title: str
     heading_hierarchy: list[str]
-    description: str
+    description: Optional[str] = None
     html_content: str
     exact_path: str
     base_path: str

--- a/govuk_chat_evaluation/rag_answers/generate.py
+++ b/govuk_chat_evaluation/rag_answers/generate.py
@@ -26,8 +26,10 @@ def generate_inputs_to_evaluation_test_cases(
         )
 
         # Extract context from result
-        retrieved_contexts = result.get("retrieved_context", [])
-        structured_context = [StructuredContext(**ctx) for ctx in retrieved_contexts]
+        retrieved_contexts = result["sources"]
+        structured_context = [
+            StructuredContext(**ctx["chunk"]) for ctx in retrieved_contexts
+        ]
 
         # TODO: this will need more data fields and may well want to validate
         # aspects of the returned data rather than just using the JSON directly


### PR DESCRIPTION
Previously the code for populating retrieved_context didn't actually do anything because the generate code wasn't configured to export source data. This commit changes this to make use of data exported by the rake task.

I've updated the code to use a sources field and to fail if it does not exist. For each source this will fail if they lack a chunk field. The reason for this change is to make it harder for this to have code that isn't actually compatible.

As part of this I've fixed an issue where description was flagged as a required field even though it is nullable in the DB.