### PR TITLE
Update output guardrail evaluation field 'question' to 'message'

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -64,8 +64,8 @@ There are more details and examples of how to do this in Retrieval and RAG Answe
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `question` | `string` | **The answer** (!) we want to evaluate against the output guardrails. |
-| `expected_triggered` | `bool` | Whether any guardrails are expected to trigger for the answer (in field: 'question'). |
+| `message` | `string` | **The answer** (!) we want to evaluate against the output guardrails. |
+| `expected_triggered` | `bool` | Whether any guardrails are expected to trigger for the answer (in field: 'message'). |
 | `expected_guardrails` | `object` | A dictionary mapping guardrail categories to booleans. `true` = guardrail expected to trigger, `false` = not expected. |
 | `actual_triggered` | `bool` | Whether any guardrails were actually triggered by the output_guardrails component. |
 | `actual_guardrails` | `object` | A dictionary mapping guardrail categories to booleans. `true` = guardrail triggered, `false` = not triggered. |
@@ -86,7 +86,7 @@ There are more details and examples of how to do this in Retrieval and RAG Answe
 
 ```json
 {
-    "question": "Example answer to test the output guardrails.",
+    "message": "Example answer to test the output guardrails.",
     "expected_triggered": true,
     "expected_guardrails": {
         "sensitive_financial_matters": true,
@@ -103,7 +103,7 @@ There are more details and examples of how to do this in Retrieval and RAG Answe
 
 ```json
 {
-    "question": "Example answer to test the output guardrails.",
+    "message": "Example answer to test the output guardrails.",
     "expected_triggered": true,
     "expected_guardrails": {
         "sensitive_financial_matters": true,

--- a/govuk_chat_evaluation/output_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/output_guardrails/evaluate.py
@@ -13,7 +13,7 @@ import logging
 
 
 class EvaluationResult(BaseModel):
-    question: str
+    message: str
     expected_triggered: bool
     actual_triggered: bool
     expected_guardrails: dict[str, bool]

--- a/govuk_chat_evaluation/output_guardrails/generate.py
+++ b/govuk_chat_evaluation/output_guardrails/generate.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 
 class GenerateInput(BaseModel):
-    question: str
+    message: str
     expected_triggered: bool
     expected_guardrails: dict[str, bool]
 
@@ -37,7 +37,7 @@ def generate_inputs_to_evaluation_results(
     generate a result"""
 
     async def generate_input_to_evaluation_result(input: GenerateInput):
-        env = {"INPUT": input.question}
+        env = {"INPUT": input.message}
         if claude_generation_model:
             env["BEDROCK_CLAUDE_GUARDRAILS_MODEL"] = claude_generation_model
 
@@ -52,7 +52,7 @@ def generate_inputs_to_evaluation_results(
             actual_guardrails[guardrail] = guardrail in triggered_guardrails
 
         return EvaluationResult(
-            question=input.question,
+            message=input.message,
             expected_triggered=input.expected_triggered,
             actual_triggered=len(triggered_guardrails) > 0,
             expected_guardrails=input.expected_guardrails,

--- a/tests/output_guardrails/conftest.py
+++ b/tests/output_guardrails/conftest.py
@@ -7,7 +7,7 @@ import pytest
 def mock_input_data(mock_project_root):
     data = [
         {
-            "question": "Question 1",
+            "message": "This answer contains inappropriate content.",
             "expected_triggered": True,
             "actual_triggered": True,
             "expected_guardrails": {"appropriate_language": True, "political": True},
@@ -15,7 +15,7 @@ def mock_input_data(mock_project_root):
             "model": "model_name",
         },
         {
-            "question": "Question 2",
+            "message": "This is a safe and appropriate answer.",
             "expected_triggered": False,
             "actual_triggered": True,
             "expected_guardrails": {"appropriate_language": False, "political": False},

--- a/tests/output_guardrails/test_cli.py
+++ b/tests/output_guardrails/test_cli.py
@@ -27,7 +27,7 @@ def mock_config_file(tmp_path, mock_input_data):
 def mock_data_generation(mocker):
     return_value = [
         EvaluationResult(
-            question="Question",
+            message="Unsafe Answer",
             expected_triggered=True,
             actual_triggered=True,
             expected_guardrails={"appropriate_language": True},
@@ -35,7 +35,7 @@ def mock_data_generation(mocker):
             model="model_name",
         ),
         EvaluationResult(
-            question="Question",
+            message="Safe Answer",
             expected_triggered=False,
             actual_triggered=False,
             expected_guardrails={"appropriate_language": False},

--- a/tests/output_guardrails/test_evaluate.py
+++ b/tests/output_guardrails/test_evaluate.py
@@ -17,7 +17,7 @@ from govuk_chat_evaluation.output_guardrails.evaluate import (
 @pytest.fixture
 def result_true_positive() -> EvaluationResult:  # type: ignore
     return EvaluationResult(
-        question="TP",
+        message="TP",
         expected_triggered=True,
         actual_triggered=True,
         expected_guardrails={"g1": True, "g3": True},
@@ -29,7 +29,7 @@ def result_true_positive() -> EvaluationResult:  # type: ignore
 @pytest.fixture
 def result_false_positive() -> EvaluationResult:  # type: ignore
     return EvaluationResult(
-        question="FP",
+        message="FP",
         expected_triggered=False,
         actual_triggered=True,
         expected_guardrails={"g1": False, "g3": False},
@@ -41,7 +41,7 @@ def result_false_positive() -> EvaluationResult:  # type: ignore
 @pytest.fixture
 def result_false_negative() -> EvaluationResult:  # type: ignore
     return EvaluationResult(
-        question="FN",
+        message="FN",
         expected_triggered=True,
         actual_triggered=False,
         expected_guardrails={"g1": True, "g3": True},
@@ -53,7 +53,7 @@ def result_false_negative() -> EvaluationResult:  # type: ignore
 @pytest.fixture
 def result_true_negative() -> EvaluationResult:  # type: ignore
     return EvaluationResult(
-        question="TN",
+        message="TN",
         expected_triggered=False,
         actual_triggered=False,
         expected_guardrails={"g1": False, "g3": False},
@@ -65,7 +65,7 @@ def result_true_negative() -> EvaluationResult:  # type: ignore
 @pytest.fixture
 def result_mixed_guardrails() -> EvaluationResult:
     return EvaluationResult(
-        question="Mixed",
+        message="Mixed",
         expected_triggered=True,
         actual_triggered=True,
         expected_guardrails={"g1": True, "g2": False, "g3": True},
@@ -97,7 +97,7 @@ class TestEvaluationResult:
     def test_for_csv(self, result_mixed_guardrails):
         result = result_mixed_guardrails
         expected_csv_dict = {
-            "question": "Mixed",
+            "message": "Mixed",
             "expected_triggered": True,
             "actual_triggered": True,
             "expected_guardrails": {"g1": True, "g2": False, "g3": True},
@@ -163,7 +163,7 @@ class TestAggregateResults:
         """Fixture providing sample results for per-guardrail testing."""
         return [
             EvaluationResult(
-                question="Q1",
+                message="Answer 1: multiple guardrails triggered correctly",
                 expected_triggered=True,
                 actual_triggered=True,
                 expected_guardrails={"g1": True, "g2": False, "g3": True},
@@ -171,7 +171,7 @@ class TestAggregateResults:
                 model="model_name",
             ),
             EvaluationResult(
-                question="Q2",
+                message="Answer 2: one guardrail false positive",
                 expected_triggered=True,
                 actual_triggered=True,
                 expected_guardrails={"g1": True, "g2": False, "g3": False},
@@ -179,7 +179,7 @@ class TestAggregateResults:
                 model="model_name",
             ),
             EvaluationResult(
-                question="Q3",
+                message="Answer 3: one guardrail false negative",
                 expected_triggered=True,
                 actual_triggered=True,
                 expected_guardrails={"g1": True, "g2": True, "g3": True},
@@ -187,7 +187,7 @@ class TestAggregateResults:
                 model="model_name",
             ),
             EvaluationResult(
-                question="Q4",
+                message="Answer 4: safe response with no issues",
                 expected_triggered=False,
                 actual_triggered=False,
                 expected_guardrails={"g1": False, "g2": False, "g3": False},
@@ -195,7 +195,7 @@ class TestAggregateResults:
                 model="model_name",
             ),
             EvaluationResult(
-                question="Q5",
+                message="Answer 5: safe but incorrectly flagged",
                 expected_triggered=False,
                 actual_triggered=True,
                 expected_guardrails={"g1": False, "g2": False, "g3": False},
@@ -203,7 +203,7 @@ class TestAggregateResults:
                 model="model_name",
             ),
             EvaluationResult(
-                question="Q6",
+                message="Answer 6: unsafe but not detected",
                 expected_triggered=True,
                 actual_triggered=False,
                 expected_guardrails={"g1": False, "g2": True, "g3": False},
@@ -252,9 +252,9 @@ class TestAggregateResults:
         precision = aggregate.precision_per_guardrail()
 
         # Calculate based on vectors: TP / (TP + FP)
-        # g1: TP=3 (Q1,Q2,Q3), FP=1 (Q5) -> P=3/4 = 0.75
-        # g2: TP=1 (Q3), FP=1 (Q2) -> P=1/2 = 0.5
-        # g3: TP=1 (Q1), FP=0 -> P=1/1 = 1.0
+        # g1: TP=3 (first 3 answers), FP=1 (Answer 5) -> P=3/4 = 0.75
+        # g2: TP=1 (Answer 3), FP=1 (Answer 2) -> P=1/2 = 0.5
+        # g3: TP=1 (Answer 1), FP=0 -> P=1/1 = 1.0
         expected_precision = [0.75, 0.5, 1.0]
         assert precision == approx(expected_precision)
 
@@ -268,9 +268,9 @@ class TestAggregateResults:
         recall = aggregate.recall_per_guardrail()
 
         # Calculate based on vectors: TP / (TP + FN)
-        # g1: TP=3 (Q1,Q2,Q3), FN=0 -> R = 3/3 = 1.0
-        # g2: TP=1 (Q3), FN=1 (Q6) -> R = 1/2 = 0.5
-        # g3: TP=1 (Q1), FN=1 (Q3) -> R = 1/2 = 0.5
+        # g1: TP=3 (first 3 answers), FN=0 -> R = 3/3 = 1.0
+        # g2: TP=1 (Answer 3), FN=1 (Answer 6) -> R = 1/2 = 0.5
+        # g3: TP=1 (Answer 1), FN=1 (Answer 3) -> R = 1/2 = 0.5
         expected_recall = [1.0, 0.5, 0.5]
         assert recall == approx(expected_recall)
 
@@ -351,7 +351,7 @@ def mock_evaluation_data_file(tmp_path):
     file_path = tmp_path / "evaluation_data.jsonl"
     data = [
         {
-            "question": "Question 1",
+            "message": "Answer with violations detected",
             "expected_triggered": True,
             "actual_triggered": True,
             "expected_guardrails": {"g1": True, "g2": False},
@@ -359,7 +359,7 @@ def mock_evaluation_data_file(tmp_path):
             "model": "model_name",
         },
         {
-            "question": "Question 2",
+            "message": "Another answer with different violations",
             "expected_triggered": True,
             "actual_triggered": False,
             "expected_guardrails": {"g1": False, "g2": True},
@@ -367,7 +367,7 @@ def mock_evaluation_data_file(tmp_path):
             "model": "model_name",
         },
         {
-            "question": "Question 3",
+            "message": "Safe answer with no issues",
             "expected_triggered": False,
             "actual_triggered": False,
             "expected_guardrails": {"g1": False, "g2": False},
@@ -375,7 +375,7 @@ def mock_evaluation_data_file(tmp_path):
             "model": "model_name",
         },
         {
-            "question": "Question 4",
+            "message": "Answer incorrectly flagged as unsafe",
             "expected_triggered": False,
             "actual_triggered": True,
             "expected_guardrails": {"g1": False, "g2": False},
@@ -405,7 +405,7 @@ def test_evaluate_and_output_results_writes_results(
         headers = next(reader, None)
 
         assert headers is not None
-        assert "question" in headers
+        assert "message" in headers
 
 
 def test_evaluate_and_output_results_writes_aggregates(

--- a/tests/output_guardrails/test_generate.py
+++ b/tests/output_guardrails/test_generate.py
@@ -15,7 +15,7 @@ from govuk_chat_evaluation.output_guardrails.evaluate import EvaluationResult
 @pytest.fixture
 def run_rake_task_mock(mocker):
     async def default_side_effect(_, env):
-        if env["INPUT"] == "Question 1":
+        if env["INPUT"] == "This answer contains inappropriate content.":
             return {
                 "triggered": True,
                 "answer_guardrails_failures": ["appropriate_language", "political"],
@@ -41,7 +41,7 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
 ):
     generate_inputs = [
         GenerateInput(
-            question="Question 1",
+            message="This answer contains inappropriate content.",
             expected_triggered=True,
             expected_guardrails={
                 "appropriate_language": True,
@@ -50,7 +50,7 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
             },
         ),
         GenerateInput(
-            question="Question 2",
+            message="This is a safe and appropriate answer.",
             expected_triggered=False,
             expected_guardrails={
                 "appropriate_language": False,
@@ -60,7 +60,7 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
     ]
     expected_results = [
         EvaluationResult(
-            question="Question 1",
+            message="This answer contains inappropriate content.",
             expected_triggered=True,
             actual_triggered=True,
             expected_guardrails={
@@ -76,7 +76,7 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
             model="model_name",
         ),
         EvaluationResult(
-            question="Question 2",
+            message="This is a safe and appropriate answer.",
             expected_triggered=False,
             actual_triggered=False,
             expected_guardrails={
@@ -94,8 +94,8 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
         "answer_guardrails", None, generate_inputs
     )
 
-    assert sorted(expected_results, key=lambda r: r.question) == sorted(
-        actual_results, key=lambda r: r.question
+    assert sorted(expected_results, key=lambda r: r.message) == sorted(
+        actual_results, key=lambda r: r.message
     )
 
 
@@ -104,7 +104,7 @@ def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
 ):
     generate_inputs = [
         GenerateInput(
-            question="Question 1",
+            message="This answer contains inappropriate content.",
             expected_triggered=True,
             expected_guardrails={"appropriate_language": True},
         ),
@@ -113,7 +113,7 @@ def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
 
     run_rake_task_mock.assert_called_with(
         "evaluation:generate_output_guardrail_response[answer_guardrails]",
-        {"INPUT": "Question 1"},
+        {"INPUT": "This answer contains inappropriate content."},
     )
 
 
@@ -122,7 +122,7 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
 ):
     generate_inputs = [
         GenerateInput(
-            question="Question 1",
+            message="This answer contains inappropriate content.",
             expected_triggered=True,
             expected_guardrails={"appropriate_language": True},
         ),
@@ -133,7 +133,10 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
 
     run_rake_task_mock.assert_called_with(
         "evaluation:generate_output_guardrail_response[answer_guardrails]",
-        {"INPUT": "Question 1", "BEDROCK_CLAUDE_GUARDRAILS_MODEL": "claude_sonnet_4_0"},
+        {
+            "INPUT": "This answer contains inappropriate content.",
+            "BEDROCK_CLAUDE_GUARDRAILS_MODEL": "claude_sonnet_4_0",
+        },
     )
 
 


### PR DESCRIPTION
While looking at the output guardrails dataset for the porting of the prompts to haiku 4.5 we updated the dataset, as part of this we renamed 'question' to 'input' for clarity as we don't expect a question, we actually expect Chat's proposed answer to the question as an input to the output_guardrails component.

We opted as a team to rename the field to input instead.

This PR contains a commit updating the relevant code and the data README.