### PR TITLE
Opt-out of Deepeval Telemtery

### DIFF
--- a/govuk_chat_evaluation/cli.py
+++ b/govuk_chat_evaluation/cli.py
@@ -1,4 +1,5 @@
 import click
+import os
 from dotenv import load_dotenv
 
 from .file_system import project_root
@@ -11,6 +12,9 @@ from . import topic_tagger
 
 load_dotenv(project_root() / ".env.aws")
 load_dotenv()
+
+# Apply a global configuration to opt-out of Deepeval sending telemetry data
+os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "1"
 
 
 @click.group()


### PR DESCRIPTION
This applies an env var to opt-out of Deepeval sending telemetry data as per [1]. I didn't think this was worth adding a test for since it's testing deepeval though if one needs to confirm that this is having an effect it can be done via:

```
>>> import govuk_chat_evaluation.cli
>>> from deepeval.config.settings import get_settings
>>> get_settings().DEEPEVAL_TELEMETRY_OPT_OUT
True
```

[1]: https://deepeval.com/docs/data-privacy#your-privacy-using-deepeval