### PR TITLE
Change config defaults to current models

### DIFF
--- a/config/defaults/rag_answers.yaml
+++ b/config/defaults/rag_answers.yaml
@@ -1,6 +1,6 @@
 what: Evaluating RAG answers
 generate: false
-provider: openai
+provider: claude
 input_path: data/rag_answers.jsonl
 claude_generation_model: ~
 metrics:

--- a/config/defaults/retrieval.yaml
+++ b/config/defaults/retrieval.yaml
@@ -1,4 +1,4 @@
 what: Evaluating retrieval
 generate: true
-embedding_provider: openai
+embedding_provider: titan
 input_path: data/retrieval.jsonl


### PR DESCRIPTION
I got caught in an error as I assumed claude would now be the default provider model for RAG answers. As it seems unlikely that anyone would expect these to default to OpenAI anymore it seems prudent to update these defaults.