### PR TITLE
[CHAT-472] Remove provider config from evaluations

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -17,7 +17,7 @@ A couple of usage tips:
 
 ### Configuring the evaluation model
 
-You can configure the model used in evaluation when the `provider` is `claude` and you are running an evaluation related to answer composition.
+You can configure the model when you are running an evaluation related to answer composition.
 
 The model must be one that is supported by the Ruby codebase. You can determine which models are supported by checking the [SUPPORTED_MODELS constant](https://github.com/search?q=repo%3Aalphagov%2Fgovuk-chat+SUPPORTED_MODELS&type=code) for the class related to the type of evaluation you are trying to run.
 

--- a/config/defaults/jailbreak_guardrails.yaml
+++ b/config/defaults/jailbreak_guardrails.yaml
@@ -1,5 +1,4 @@
 what: Evaluating jailbreak guardrails
 generate: true
-provider: claude
 input_path: data/jailbreak_guardrails.jsonl
 claude_generation_model: ~

--- a/config/defaults/output_guardrails.yaml
+++ b/config/defaults/output_guardrails.yaml
@@ -1,6 +1,5 @@
 what: Evaluating output guardrails
 guardrail_type: answer_guardrails
 generate: true
-provider: claude
 input_path: data/output_guardrails.jsonl
 claude_generation_model: ~

--- a/config/defaults/question_router.yaml
+++ b/config/defaults/question_router.yaml
@@ -1,5 +1,4 @@
 what: Evaluating question router
 generate: true
-provider: claude
 input_path: data/question_router.jsonl
 claude_generation_model: ~

--- a/config/defaults/rag_answers.yaml
+++ b/config/defaults/rag_answers.yaml
@@ -1,6 +1,5 @@
 what: Evaluating RAG answers
 generate: false
-provider: claude
 input_path: data/rag_answers.jsonl
 claude_generation_model: ~
 metrics:

--- a/config/defaults/retrieval.yaml
+++ b/config/defaults/retrieval.yaml
@@ -1,4 +1,3 @@
 what: Evaluating retrieval
 generate: true
-embedding_provider: titan
 input_path: data/retrieval.jsonl

--- a/govuk_chat_evaluation/config.py
+++ b/govuk_chat_evaluation/config.py
@@ -40,8 +40,9 @@ class BaseConfig(BaseModel):
             Field(
                 None,
                 description=(
-                    "Which Claude model to use for generating the data when the provider is Claude, e.g. "
-                    "claude_sonnet_4_0 or claude_haiku_4_5. If not specified, the default model will be used."
+                    "Which Claude model to use for generating the data e.g. "
+                    "claude_sonnet_4_0 or claude_haiku_4_5. If not specified, "
+                    "the default model will be used."
                 ),
             ),
         ]

--- a/govuk_chat_evaluation/config.py
+++ b/govuk_chat_evaluation/config.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import (
     Annotated,
     Any,
-    Literal,
     Optional,
     Self,
     Type,
@@ -25,13 +24,6 @@ class BaseConfig(BaseModel):
 
         what = Annotated[str, Field(..., description="What is being evaluated")]
         generate = Annotated[bool, Field(..., description="Whether to generate data")]
-        provider_openai_or_claude = Annotated[
-            Optional[Literal["openai", "claude"]],
-            Field(
-                None,
-                description="Which provider to use for generating the data, openai or claude",
-            ),
-        ]
         input_path = Annotated[
             FilePath, Field(..., description="Path to the data file used to evaluate")
         ]

--- a/govuk_chat_evaluation/jailbreak_guardrails/cli.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/cli.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Self, cast
 
 import click
-from pydantic import model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import write_config_file_for_reuse
@@ -15,13 +13,8 @@ from ..output import initialise_output
 class Config(BaseConfig):
     what: BaseConfig.GenericFields.what
     generate: BaseConfig.GenericFields.generate
-    provider: BaseConfig.GenericFields.provider_openai_or_claude
     input_path: BaseConfig.GenericFields.input_path
     claude_generation_model: BaseConfig.GenericFields.claude_generation_model
-
-    @model_validator(mode="after")
-    def run_validatons(self) -> Self:
-        return self._validate_fields_required_for_generate("provider")
 
 
 @click.command(name="jailbreak_guardrails")
@@ -46,7 +39,6 @@ def main(**cli_args):
     if config.generate:
         evaluate_path = generate_and_write_dataset(
             config.input_path,
-            cast(str, config.provider),
             config.claude_generation_model,
             output_dir=output_dir,
         )

--- a/govuk_chat_evaluation/jailbreak_guardrails/generate.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/generate.py
@@ -17,19 +17,15 @@ class GenerateInput(BaseModel):
 
 def generate_and_write_dataset(
     input_path: Path,
-    provider: str,
     claude_generation_model: Optional[str],
     output_dir: Path,
 ):
     models = jsonl_to_models(input_path, GenerateInput)
-    generated = generate_inputs_to_evaluation_results(
-        provider, claude_generation_model, models
-    )
+    generated = generate_inputs_to_evaluation_results(claude_generation_model, models)
     return write_generated_to_output(output_dir, generated)
 
 
 def generate_inputs_to_evaluation_results(
-    provider: str,
     claude_generation_model: Optional[str],
     generate_inputs: list[GenerateInput],
 ) -> list[EvaluationResult]:
@@ -42,7 +38,7 @@ def generate_inputs_to_evaluation_results(
             env["BEDROCK_CLAUDE_JAILBREAK_GUARDRAILS_MODEL"] = claude_generation_model
 
         result = await run_rake_task(
-            f"evaluation:generate_jailbreak_guardrail_response[{provider}]",
+            "evaluation:generate_jailbreak_guardrail_response",
             env,
         )
 

--- a/govuk_chat_evaluation/output_guardrails/cli.py
+++ b/govuk_chat_evaluation/output_guardrails/cli.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, Self, cast
+from typing import Literal
 
 import click
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import write_config_file_for_reuse
@@ -15,17 +15,12 @@ from ..output import initialise_output
 class Config(BaseConfig):
     what: BaseConfig.GenericFields.what
     generate: BaseConfig.GenericFields.generate
-    provider: BaseConfig.GenericFields.provider_openai_or_claude
     input_path: BaseConfig.GenericFields.input_path
     guardrail_type: Literal["answer_guardrails", "question_routing_guardrails"] = Field(
         ...,
         description="Type of output guardrail to evaluate: 'answer_guardrails' or 'question_router_guardrails'",
     )
     claude_generation_model: BaseConfig.GenericFields.claude_generation_model
-
-    @model_validator(mode="after")
-    def run_validatons(self) -> Self:
-        return self._validate_fields_required_for_generate("provider")
 
 
 @click.command(name="output_guardrails")
@@ -50,7 +45,6 @@ def main(**cli_args):
     if config.generate:
         evaluate_path = generate_and_write_dataset(
             config.input_path,
-            cast(str, config.provider),
             config.guardrail_type,
             config.claude_generation_model,
             output_dir,

--- a/govuk_chat_evaluation/output_guardrails/generate.py
+++ b/govuk_chat_evaluation/output_guardrails/generate.py
@@ -17,20 +17,18 @@ class GenerateInput(BaseModel):
 
 def generate_and_write_dataset(
     input_path: Path,
-    provider: str,
     guardrail_type: str,
     claude_generation_model: Optional[str],
     output_dir: Path,
 ):
     models = jsonl_to_models(input_path, GenerateInput)
     generated = generate_inputs_to_evaluation_results(
-        provider, guardrail_type, claude_generation_model, models
+        guardrail_type, claude_generation_model, models
     )
     return write_generated_to_output(output_dir, generated)
 
 
 def generate_inputs_to_evaluation_results(
-    provider: str,
     guardrail_type: str,
     claude_generation_model: Optional[str],
     generate_inputs: list[GenerateInput],
@@ -44,7 +42,7 @@ def generate_inputs_to_evaluation_results(
             env["BEDROCK_CLAUDE_GUARDRAILS_MODEL"] = claude_generation_model
 
         result = await run_rake_task(
-            f"evaluation:generate_output_guardrail_response[{provider},{guardrail_type}]",
+            f"evaluation:generate_output_guardrail_response[{guardrail_type}]",
             env,
         )
 

--- a/govuk_chat_evaluation/question_router/cli.py
+++ b/govuk_chat_evaluation/question_router/cli.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Self, cast
 
 import click
-from pydantic import model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import write_config_file_for_reuse
@@ -15,13 +13,8 @@ from ..output import initialise_output
 class Config(BaseConfig):
     what: BaseConfig.GenericFields.what
     generate: BaseConfig.GenericFields.generate
-    provider: BaseConfig.GenericFields.provider_openai_or_claude
     input_path: BaseConfig.GenericFields.input_path
     claude_generation_model: BaseConfig.GenericFields.claude_generation_model
-
-    @model_validator(mode="after")
-    def run_validatons(self) -> Self:
-        return self._validate_fields_required_for_generate("provider")
 
 
 @click.command(name="question_router")
@@ -46,7 +39,6 @@ def main(**cli_args):
     if config.generate:
         evaluate_path = generate_and_write_dataset(
             config.input_path,
-            cast(str, config.provider),
             config.claude_generation_model,
             output_dir,
         )

--- a/govuk_chat_evaluation/question_router/generate.py
+++ b/govuk_chat_evaluation/question_router/generate.py
@@ -16,19 +16,15 @@ class GenerateInput(BaseModel):
 
 def generate_and_write_dataset(
     input_path: Path,
-    provider: str,
     claude_generation_model: Optional[str],
     output_dir: Path,
 ):
     models = jsonl_to_models(Path(input_path), GenerateInput)
-    generated = generate_inputs_to_evaluation_results(
-        provider, claude_generation_model, models
-    )
+    generated = generate_inputs_to_evaluation_results(claude_generation_model, models)
     return write_generated_to_output(output_dir, generated)
 
 
 def generate_inputs_to_evaluation_results(
-    provider: str,
     claude_generation_model: Optional[str],
     generate_inputs: list[GenerateInput],
 ) -> list[EvaluationResult]:
@@ -41,7 +37,7 @@ def generate_inputs_to_evaluation_results(
             env["BEDROCK_CLAUDE_QUESTION_ROUTER_MODEL"] = claude_generation_model
 
         result = await run_rake_task(
-            f"evaluation:generate_question_routing_response[{provider}]",
+            "evaluation:generate_question_routing_response",
             env,
         )
 

--- a/govuk_chat_evaluation/rag_answers/cli.py
+++ b/govuk_chat_evaluation/rag_answers/cli.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from pathlib import Path
-from typing import cast
 
 import click
 
@@ -35,7 +34,6 @@ def main(**cli_args):
     if config.generate:
         evaluate_path = generate_and_write_dataset(
             config.input_path,
-            cast(str, config.provider),
             config.claude_generation_model,
             output_dir,
         )

--- a/govuk_chat_evaluation/rag_answers/data_models/config.py
+++ b/govuk_chat_evaluation/rag_answers/data_models/config.py
@@ -131,15 +131,10 @@ class MetricConfig(BaseModel):
 class TaskConfig(BaseConfig):
     what: BaseConfig.GenericFields.what
     generate: BaseConfig.GenericFields.generate
-    provider: BaseConfig.GenericFields.provider_openai_or_claude
     input_path: BaseConfig.GenericFields.input_path
     claude_generation_model: BaseConfig.GenericFields.claude_generation_model
     metrics: list[MetricConfig]
     n_runs: int
-
-    @model_validator(mode="after")
-    def run_validatons(self):
-        return self._validate_fields_required_for_generate("provider")
 
     def metric_instances(self) -> list[BaseMetric]:
         """Return the list of runtime metric objects for evaluation."""

--- a/govuk_chat_evaluation/rag_answers/generate.py
+++ b/govuk_chat_evaluation/rag_answers/generate.py
@@ -16,21 +16,19 @@ from typing import Optional
 
 def generate_and_write_dataset(
     input_path: Path,
-    provider: str,
     claude_generation_model: Optional[str],
     output_dir: Path,
 ):
     models = jsonl_to_models(Path(input_path), GenerateInput)
     ensure_unique_model_ids(models)
     generated = generate_inputs_to_evaluation_test_cases(
-        provider, claude_generation_model, models
+        claude_generation_model, models
     )
 
     return write_generated_to_output(output_dir, generated)
 
 
 def generate_inputs_to_evaluation_test_cases(
-    provider: str,
     claude_generation_model: Optional[str],
     generate_inputs: list[GenerateInput],
 ) -> list[EvaluationTestCase]:
@@ -47,7 +45,7 @@ def generate_inputs_to_evaluation_test_cases(
             env["OPENSEARCH_INDEX"] = input.expected_opensearch_index
 
         result = await run_rake_task(
-            f"evaluation:generate_rag_structured_answer_response[{provider}]",
+            "evaluation:generate_rag_structured_answer_response",
             env,
         )
 

--- a/govuk_chat_evaluation/retrieval/cli.py
+++ b/govuk_chat_evaluation/retrieval/cli.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Self, Annotated, Optional, Literal, cast
 
 import click
-from pydantic import Field, model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import create_output_directory, write_config_file_for_reuse
@@ -14,18 +12,7 @@ from .generate import generate_and_write_dataset
 class Config(BaseConfig):
     what: BaseConfig.GenericFields.what
     generate: BaseConfig.GenericFields.generate
-    embedding_provider: Annotated[
-        Optional[Literal["openai", "titan"]],
-        Field(
-            None,
-            description="Which LLM provider to use for generating the embeddings: openai or titan",
-        ),
-    ]
     input_path: BaseConfig.GenericFields.input_path
-
-    @model_validator(mode="after")
-    def run_validatons(self) -> Self:
-        return self._validate_fields_required_for_generate("embedding_provider")
 
 
 @click.command(name="retrieval")
@@ -48,9 +35,7 @@ def main(**cli_args):
     output_dir = create_output_directory("retrieval", start_time)
 
     if config.generate:
-        evaluate_path = generate_and_write_dataset(
-            config.input_path, cast(str, config.embedding_provider), output_dir
-        )
+        evaluate_path = generate_and_write_dataset(config.input_path, output_dir)
     else:
         evaluate_path = config.input_path
 

--- a/govuk_chat_evaluation/retrieval/generate.py
+++ b/govuk_chat_evaluation/retrieval/generate.py
@@ -16,22 +16,20 @@ class GenerateInput(BaseModel):
     expected_opensearch_index: Optional[str] = None
 
 
-def generate_and_write_dataset(
-    input_path: Path, embedding_provider: str, output_dir: Path
-):
+def generate_and_write_dataset(input_path: Path, output_dir: Path):
     models = jsonl_to_models(Path(input_path), GenerateInput)
-    generated = generate_inputs_to_evaluation_results(embedding_provider, models)
+    generated = generate_inputs_to_evaluation_results(models)
     return write_generated_to_output(output_dir, generated)
 
 
 def generate_inputs_to_evaluation_results(
-    embedding_provider: str, generate_inputs: list[GenerateInput]
+    generate_inputs: list[GenerateInput],
 ) -> list[EvaluationResult]:
     """Asynchronously run rake tasks for each GenerateInput instance to
     generate a result"""
 
     async def generate_input_to_evaluation_result(input: GenerateInput):
-        env = {"INPUT": input.question, "EMBEDDING_PROVIDER": embedding_provider}
+        env = {"INPUT": input.question}
         if input.expected_opensearch_index:
             env["OPENSEARCH_INDEX"] = input.expected_opensearch_index
 

--- a/govuk_chat_evaluation/topic_tagger/cli.py
+++ b/govuk_chat_evaluation/topic_tagger/cli.py
@@ -13,7 +13,6 @@ from ..output import initialise_output
 class Config(BaseConfig):
     what: BaseConfig.GenericFields.what
     generate: BaseConfig.GenericFields.generate
-    provider: BaseConfig.GenericFields.provider_openai_or_claude
     input_path: BaseConfig.GenericFields.input_path
 
 

--- a/tests/jailbreak_guardrails/test_cli.py
+++ b/tests/jailbreak_guardrails/test_cli.py
@@ -2,36 +2,8 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from govuk_chat_evaluation.jailbreak_guardrails.cli import main, Config
+from govuk_chat_evaluation.jailbreak_guardrails.cli import main
 from govuk_chat_evaluation.jailbreak_guardrails.evaluate import EvaluationResult
-
-
-class TestConfig:
-    def test_config_requires_provider_for_generate(self, mock_input_data):
-        with pytest.raises(ValueError, match="provider is required to generate data"):
-            Config(
-                what="Test",
-                generate=True,
-                provider=None,
-                input_path=mock_input_data,
-                claude_generation_model=None,
-            )
-
-        Config(
-            what="Test",
-            generate=False,
-            provider=None,
-            input_path=mock_input_data,
-            claude_generation_model=None,
-        )
-
-        Config(
-            what="Test",
-            generate=True,
-            provider="openai",
-            input_path=mock_input_data,
-            claude_generation_model=None,
-        )
 
 
 @pytest.fixture(autouse=True)
@@ -39,7 +11,6 @@ def mock_config_file(tmp_path, mock_input_data):
     """Write a config file as an input for testing"""
     data = {
         "what": "Testing Jailbreak Guardrail evaluations",
-        "provider": "openai",
         "generate": True,
         "input_path": str(mock_input_data),
         "claude_generation_model": "claude_sonnet_4_0",
@@ -103,7 +74,7 @@ def test_main_passes_claude_generation_model_to_generate_and_write_dataset(
 ):
     runner = CliRunner()
     runner.invoke(main, [mock_config_file])
-    claude_generation_model = mock_data_generation.call_args[0][1]
+    claude_generation_model = mock_data_generation.call_args[0][0]
 
     mock_data_generation.assert_called_once()
     assert claude_generation_model == "claude_sonnet_4_0"
@@ -113,9 +84,7 @@ def test_main_generates_results(
     mock_output_directory, mock_config_file, mock_data_generation
 ):
     runner = CliRunner()
-    result = runner.invoke(
-        main, [mock_config_file, "--generate", "--provider", "claude"]
-    )
+    result = runner.invoke(main, [mock_config_file, "--generate"])
 
     generated_file = mock_output_directory / "generated.jsonl"
 

--- a/tests/jailbreak_guardrails/test_generate.py
+++ b/tests/jailbreak_guardrails/test_generate.py
@@ -49,9 +49,7 @@ def test_generate_models_to_evaluation_results_returns_evaluation_results(
             model="model_name",
         ),
     ]
-    actual_results = generate_inputs_to_evaluation_results(
-        "openai", None, generate_inputs
-    )
+    actual_results = generate_inputs_to_evaluation_results(None, generate_inputs)
 
     assert sorted(expected_results, key=lambda r: r.question) == sorted(
         actual_results, key=lambda r: r.question
@@ -68,9 +66,7 @@ def test_generate_models_to_evaluation_results_copes_with_response_errors(
     generate_inputs = [
         GenerateInput(question="Question 1", expected_outcome=True),
     ]
-    actual_results = generate_inputs_to_evaluation_results(
-        "claude", None, generate_inputs
-    )
+    actual_results = generate_inputs_to_evaluation_results(None, generate_inputs)
 
     log_message = (
         "Invalid response for 'Question 1', returned: "
@@ -89,7 +85,7 @@ def test_generate_models_to_evaluation_results_raises_on_unexpected_key(
         GenerateInput(question="Question 1", expected_outcome=True),
     ]
     with pytest.raises(RuntimeError) as exc_info:
-        generate_inputs_to_evaluation_results("claude", None, generate_inputs)
+        generate_inputs_to_evaluation_results(None, generate_inputs)
 
     assert "Unexpected result structure {'what': {'triggered': True}}" in str(
         exc_info.value
@@ -102,10 +98,10 @@ def test_generate_models_to_evaluation_models_runs_expected_rake_task(
     generate_inputs = [
         GenerateInput(question="Question 1", expected_outcome=True),
     ]
-    generate_inputs_to_evaluation_results("openai", None, generate_inputs)
+    generate_inputs_to_evaluation_results(None, generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_jailbreak_guardrail_response[openai]",
+        "evaluation:generate_jailbreak_guardrail_response",
         {"INPUT": "Question 1"},
     )
 
@@ -116,12 +112,10 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
     generate_inputs = [
         GenerateInput(question="Question 1", expected_outcome=True),
     ]
-    generate_inputs_to_evaluation_results(
-        "claude", "claude_sonnet_4_0", generate_inputs
-    )
+    generate_inputs_to_evaluation_results("claude_sonnet_4_0", generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_jailbreak_guardrail_response[claude]",
+        "evaluation:generate_jailbreak_guardrail_response",
         {
             "INPUT": "Question 1",
             "BEDROCK_CLAUDE_JAILBREAK_GUARDRAILS_MODEL": "claude_sonnet_4_0",
@@ -131,9 +125,7 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
 
 @pytest.mark.usefixtures("run_rake_task_mock")
 def test_generate_and_write_dataset(mock_input_data, mock_project_root):
-    path = generate_and_write_dataset(
-        mock_input_data, "openai", None, mock_project_root
-    )
+    path = generate_and_write_dataset(mock_input_data, None, mock_project_root)
     assert path.exists()
     with open(path, "r") as file:
         for line in file:

--- a/tests/output_guardrails/test_cli.py
+++ b/tests/output_guardrails/test_cli.py
@@ -2,39 +2,8 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from govuk_chat_evaluation.output_guardrails.cli import main, Config
+from govuk_chat_evaluation.output_guardrails.cli import main
 from govuk_chat_evaluation.output_guardrails.evaluate import EvaluationResult
-
-
-class TestConfig:
-    def test_config_requires_provider_for_generate(self, mock_input_data):
-        with pytest.raises(ValueError, match="provider is required to generate data"):
-            Config(
-                what="Test",
-                guardrail_type="answer_guardrails",
-                generate=True,
-                provider=None,
-                input_path=mock_input_data,
-                claude_generation_model=None,
-            )
-
-        Config(
-            what="Test",
-            guardrail_type="answer_guardrails",
-            generate=False,
-            provider=None,
-            input_path=mock_input_data,
-            claude_generation_model=None,
-        )
-
-        Config(
-            what="Test",
-            guardrail_type="answer_guardrails",
-            generate=True,
-            provider="openai",
-            input_path=mock_input_data,
-            claude_generation_model=None,
-        )
 
 
 @pytest.fixture(autouse=True)
@@ -44,7 +13,6 @@ def mock_config_file(tmp_path, mock_input_data):
         "what": "Testing Output Guardrail evaluations",
         "guardrail_type": "answer_guardrails",
         "generate": True,
-        "provider": "claude",
         "input_path": str(mock_input_data),
         "claude_generation_model": "claude_sonnet_4_0",
     }
@@ -110,7 +78,7 @@ def test_main_passes_claude_generation_model_to_generate_and_write_dataset(
 ):
     runner = CliRunner()
     runner.invoke(main, [mock_config_file])
-    claude_generation_model = mock_data_generation.call_args[0][2]
+    claude_generation_model = mock_data_generation.call_args[0][1]
 
     mock_data_generation.assert_called_once()
     assert claude_generation_model == "claude_sonnet_4_0"
@@ -120,9 +88,7 @@ def test_main_generates_results(
     mock_output_directory, mock_config_file, mock_data_generation
 ):
     runner = CliRunner()
-    result = runner.invoke(
-        main, [mock_config_file, "--generate", "--provider", "claude"]
-    )
+    result = runner.invoke(main, [mock_config_file, "--generate"])
 
     generated_file = mock_output_directory / "generated.jsonl"
 

--- a/tests/output_guardrails/test_generate.py
+++ b/tests/output_guardrails/test_generate.py
@@ -100,7 +100,7 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
         ),
     ]
     actual_results = generate_inputs_to_evaluation_results(
-        "openai", "answer_guardrails", None, generate_inputs
+        "answer_guardrails", None, generate_inputs
     )
 
     assert sorted(expected_results, key=lambda r: r.question) == sorted(
@@ -118,12 +118,10 @@ def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
             expected_guardrails={"appropriate_language": True},
         ),
     ]
-    generate_inputs_to_evaluation_results(
-        "openai", "answer_guardrails", None, generate_inputs
-    )
+    generate_inputs_to_evaluation_results("answer_guardrails", None, generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_output_guardrail_response[openai,answer_guardrails]",
+        "evaluation:generate_output_guardrail_response[answer_guardrails]",
         {"INPUT": "Question 1"},
     )
 
@@ -139,11 +137,11 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
         ),
     ]
     generate_inputs_to_evaluation_results(
-        "claude", "answer_guardrails", "claude_sonnet_4_0", generate_inputs
+        "answer_guardrails", "claude_sonnet_4_0", generate_inputs
     )
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_output_guardrail_response[claude,answer_guardrails]",
+        "evaluation:generate_output_guardrail_response[answer_guardrails]",
         {"INPUT": "Question 1", "BEDROCK_CLAUDE_GUARDRAILS_MODEL": "claude_sonnet_4_0"},
     )
 
@@ -151,7 +149,7 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
 @pytest.mark.usefixtures("run_rake_task_mock")
 def test_generate_and_write_dataset(mock_input_data, mock_project_root):
     path = generate_and_write_dataset(
-        mock_input_data, "openai", "answer_guardrails", None, mock_project_root
+        mock_input_data, "answer_guardrails", None, mock_project_root
     )
     assert path.exists()
     with open(path, "r") as file:

--- a/tests/question_router/test_cli.py
+++ b/tests/question_router/test_cli.py
@@ -2,36 +2,8 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from govuk_chat_evaluation.question_router.cli import main, Config
+from govuk_chat_evaluation.question_router.cli import main
 from govuk_chat_evaluation.question_router.evaluate import EvaluationResult
-
-
-class TestConfig:
-    def test_config_requires_provider_for_generate(self, mock_input_data):
-        with pytest.raises(ValueError, match="provider is required to generate data"):
-            Config(
-                what="Test",
-                generate=True,
-                provider=None,
-                input_path=mock_input_data,
-                claude_generation_model=None,
-            )
-
-        Config(
-            what="Test",
-            generate=False,
-            provider=None,
-            input_path=mock_input_data,
-            claude_generation_model=None,
-        )
-
-        Config(
-            what="Test",
-            generate=True,
-            provider="openai",
-            input_path=mock_input_data,
-            claude_generation_model=None,
-        )
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +12,6 @@ def mock_config_file(tmp_path, mock_input_data):
     data = {
         "what": "Testing question router evaluations",
         "generate": True,
-        "provider": "claude",
         "input_path": str(mock_input_data),
         "claude_generation_model": "claude_sonnet_4_0",
     }
@@ -108,7 +79,7 @@ def test_main_passes_claude_generation_model_to_generate_and_write_dataset(
 ):
     runner = CliRunner()
     runner.invoke(main, [mock_config_file])
-    claude_generation_model = mock_data_generation.call_args[0][1]
+    claude_generation_model = mock_data_generation.call_args[0][0]
 
     mock_data_generation.assert_called_once()
     assert claude_generation_model == "claude_sonnet_4_0"
@@ -118,9 +89,7 @@ def test_main_generates_results(
     mock_output_directory, mock_config_file, mock_data_generation
 ):
     runner = CliRunner()
-    result = runner.invoke(
-        main, [mock_config_file, "--generate", "--provider", "claude"]
-    )
+    result = runner.invoke(main, [mock_config_file, "--generate"])
 
     generated_file = mock_output_directory / "generated.jsonl"
 

--- a/tests/question_router/test_generate.py
+++ b/tests/question_router/test_generate.py
@@ -68,9 +68,7 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
             model="model_name",
         ),
     ]
-    actual_results = generate_inputs_to_evaluation_results(
-        "openai", None, generate_inputs
-    )
+    actual_results = generate_inputs_to_evaluation_results(None, generate_inputs)
 
     assert sorted(expected_results, key=lambda r: r.question) == sorted(
         actual_results, key=lambda r: r.question
@@ -86,10 +84,10 @@ def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
             expected_outcome="genuine_rag",
         ),
     ]
-    generate_inputs_to_evaluation_results("openai", None, generate_inputs)
+    generate_inputs_to_evaluation_results(None, generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_question_routing_response[openai]",
+        "evaluation:generate_question_routing_response",
         {"INPUT": "Question 1"},
     )
 
@@ -103,12 +101,10 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
             expected_outcome="genuine_rag",
         ),
     ]
-    generate_inputs_to_evaluation_results(
-        "claude", "claude_sonnet_4_0", generate_inputs
-    )
+    generate_inputs_to_evaluation_results("claude_sonnet_4_0", generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_question_routing_response[claude]",
+        "evaluation:generate_question_routing_response",
         {
             "INPUT": "Question 1",
             "BEDROCK_CLAUDE_QUESTION_ROUTER_MODEL": "claude_sonnet_4_0",
@@ -118,9 +114,7 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
 
 @pytest.mark.usefixtures("run_rake_task_mock")
 def test_generate_and_write_dataset(mock_input_data, mock_project_root):
-    path = generate_and_write_dataset(
-        mock_input_data, "openai", None, mock_project_root
-    )
+    path = generate_and_write_dataset(mock_input_data, None, mock_project_root)
     assert path.exists()
     with open(path, "r") as file:
         for line in file:

--- a/tests/rag_answers/conftest.py
+++ b/tests/rag_answers/conftest.py
@@ -48,7 +48,6 @@ def mock_config_file(tmp_path, mock_input_data):
     data = {
         "what": "Testing RAG Answer evaluations",
         "generate": True,
-        "provider": "openai",
         "input_path": str(mock_input_data),
         "claude_generation_model": "claude_sonnet_4_0",
         "metrics": [

--- a/tests/rag_answers/data_models/test_config.py
+++ b/tests/rag_answers/data_models/test_config.py
@@ -33,7 +33,6 @@ class TestMetricConfig:
         return TaskConfig(
             what="Test",
             generate=False,
-            provider=None,
             input_path=mock_input_data,
             claude_generation_model=None,
             metrics=[],
@@ -163,44 +162,10 @@ class TestMetricConfig:
 
 
 class TestTaskConfig:
-    def test_config_requires_provider_for_generate(self, mock_input_data):
-        with pytest.raises(ValueError, match="provider is required to generate data"):
-            TaskConfig(
-                what="Test",
-                generate=True,
-                provider=None,
-                input_path=mock_input_data,
-                claude_generation_model=None,
-                metrics=[],
-                n_runs=1,
-            )
-
-        # These should not raise
-        TaskConfig(
-            what="Test",
-            generate=False,
-            provider=None,
-            input_path=mock_input_data,
-            claude_generation_model=None,
-            metrics=[],
-            n_runs=1,
-        )
-
-        TaskConfig(
-            what="Test",
-            generate=True,
-            provider="openai",
-            input_path=mock_input_data,
-            claude_generation_model=None,
-            metrics=[],
-            n_runs=1,
-        )
-
     def test_get_metric_instances(self, mock_input_data):
         config_dict = {
             "what": "Test",
             "generate": False,
-            "provider": None,
             "input_path": mock_input_data,
             "metrics": [
                 {
@@ -231,7 +196,6 @@ class TestTaskConfig:
         config_dict = {
             "what": "Test",
             "generate": False,
-            "provider": None,
             "input_path": mock_input_data,
             "metrics": [
                 {

--- a/tests/rag_answers/test_cli.py
+++ b/tests/rag_answers/test_cli.py
@@ -65,7 +65,7 @@ def test_main_passes_claude_generation_model_to_generate_and_write_dataset(
 ):
     runner = CliRunner()
     runner.invoke(main, [mock_config_file])
-    claude_generation_model = mock_data_generation.call_args[0][1]
+    claude_generation_model = mock_data_generation.call_args[0][0]
 
     mock_data_generation.assert_called_once()
     assert claude_generation_model == "claude_sonnet_4_0"

--- a/tests/rag_answers/test_generate.py
+++ b/tests/rag_answers/test_generate.py
@@ -94,9 +94,7 @@ def test_generate_models_to_evaluation_test_cases_returns_evaluation_test_cases(
             model="model_name",
         ),
     ]
-    actual_results = generate_inputs_to_evaluation_test_cases(
-        "openai", None, generate_inputs
-    )
+    actual_results = generate_inputs_to_evaluation_test_cases(None, generate_inputs)
 
     assert sorted(expected_results, key=lambda r: r.question) == sorted(
         actual_results, key=lambda r: r.question
@@ -115,10 +113,10 @@ def test_generate_models_to_evaluation_test_cases_runs_expected_rake_task(
     generate_inputs = [
         GenerateInput(question="Question 1", ideal_answer="Answer"),
     ]
-    generate_inputs_to_evaluation_test_cases("openai", None, generate_inputs)
+    generate_inputs_to_evaluation_test_cases(None, generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_rag_structured_answer_response[openai]",
+        "evaluation:generate_rag_structured_answer_response",
         {"INPUT": "Question 1"},
     )
 
@@ -136,12 +134,10 @@ def test_generate_models_with_claude_generation_model_populates_model_env_var_fo
         GenerateInput(question="Question 1", ideal_answer="Answer"),
     ]
 
-    generate_inputs_to_evaluation_test_cases(
-        "claude", "claude_sonnet_4_0", generate_inputs
-    )
+    generate_inputs_to_evaluation_test_cases("claude_sonnet_4_0", generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_rag_structured_answer_response[claude]",
+        "evaluation:generate_rag_structured_answer_response",
         {
             "INPUT": "Question 1",
             "BEDROCK_CLAUDE_STRUCTURED_ANSWER_COMPOSER_MODEL": "claude_sonnet_4_0",
@@ -165,19 +161,17 @@ def test_generate_models_with_opensearch_index_populates_model_env_var_for_rake_
             expected_opensearch_index="test-index",
         ),
     ]
-    generate_inputs_to_evaluation_test_cases("openai", None, generate_inputs)
+    generate_inputs_to_evaluation_test_cases(None, generate_inputs)
 
     run_rake_task_mock.assert_called_with(
-        "evaluation:generate_rag_structured_answer_response[openai]",
+        "evaluation:generate_rag_structured_answer_response",
         {"INPUT": "Question 1", "OPENSEARCH_INDEX": "test-index"},
     )
 
 
 @pytest.mark.usefixtures("run_rake_task_mock")
 def test_generate_and_write_dataset(mock_input_data, mock_project_root):
-    path = generate_and_write_dataset(
-        mock_input_data, "openai", None, mock_project_root
-    )
+    path = generate_and_write_dataset(mock_input_data, None, mock_project_root)
     assert path.exists()
     with open(path, "r") as file:
         for line in file:
@@ -192,5 +186,5 @@ def test_generate_and_write_dataset_calls_ensure_unique_model_ids(
         "govuk_chat_evaluation.rag_answers.generate.ensure_unique_model_ids"
     ) as mock:
         mock.side_effect = lambda inputs: inputs
-        generate_and_write_dataset(mock_input_data, "openai", None, mock_project_root)
+        generate_and_write_dataset(mock_input_data, None, mock_project_root)
         mock.assert_called_once()

--- a/tests/retrieval/test_cli.py
+++ b/tests/retrieval/test_cli.py
@@ -2,38 +2,11 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from govuk_chat_evaluation.retrieval.cli import main, Config
+from govuk_chat_evaluation.retrieval.cli import main
 from govuk_chat_evaluation.retrieval.evaluate import (
     EvaluationResult,
     SearchResult,
 )
-
-
-class TestConfig:
-    def test_config_requires_provider_for_generate(self, mock_input_data):
-        with pytest.raises(
-            ValueError, match="embedding_provider is required to generate data"
-        ):
-            Config(
-                what="Test",
-                generate=True,
-                embedding_provider=None,
-                input_path=mock_input_data,
-            )
-
-        Config(
-            what="Test",
-            generate=False,
-            embedding_provider=None,
-            input_path=mock_input_data,
-        )
-
-        Config(
-            what="Test",
-            generate=True,
-            embedding_provider="openai",
-            input_path=mock_input_data,
-        )
 
 
 @pytest.fixture(autouse=True)
@@ -42,7 +15,6 @@ def mock_config_file(tmp_path, mock_input_data):
     data = {
         "what": "Testing question router evaluations",
         "generate": True,
-        "embedding_provider": "titan",
         "input_path": str(mock_input_data),
     }
     file_path = tmp_path / "config.yaml"
@@ -124,9 +96,7 @@ def test_main_generates_results(
     mock_output_directory, mock_config_file, mock_data_generation
 ):
     runner = CliRunner()
-    result = runner.invoke(
-        main, [mock_config_file, "--generate", "--embedding_provider", "titan"]
-    )
+    result = runner.invoke(main, [mock_config_file, "--generate"])
 
     generated_file = mock_output_directory / "generated.jsonl"
 

--- a/tests/retrieval/test_generate.py
+++ b/tests/retrieval/test_generate.py
@@ -135,7 +135,7 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
             ],
         ),
     ]
-    actual_results = generate_inputs_to_evaluation_results("titan", generate_inputs)
+    actual_results = generate_inputs_to_evaluation_results(generate_inputs)
 
     assert sorted(expected_results, key=lambda r: r.question) == sorted(
         actual_results, key=lambda r: r.question
@@ -153,11 +153,11 @@ def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
         ),
     ]
 
-    generate_inputs_to_evaluation_results("titan", generate_inputs)
+    generate_inputs_to_evaluation_results(generate_inputs)
 
     run_rake_task_mock.assert_called_with(
         "evaluation:search_results_for_question",
-        {"INPUT": "Question 1", "EMBEDDING_PROVIDER": "titan"},
+        {"INPUT": "Question 1"},
     )
 
 
@@ -173,13 +173,12 @@ def test_generate_inputs_to_evaluation_results_includes_opensearch_index_in_env_
         ),
     ]
 
-    generate_inputs_to_evaluation_results("titan", generate_inputs)
+    generate_inputs_to_evaluation_results(generate_inputs)
 
     run_rake_task_mock.assert_called_with(
         "evaluation:search_results_for_question",
         {
             "INPUT": "Question 1",
-            "EMBEDDING_PROVIDER": "titan",
             "OPENSEARCH_INDEX": "custom-index",
         },
     )
@@ -187,7 +186,7 @@ def test_generate_inputs_to_evaluation_results_includes_opensearch_index_in_env_
 
 @pytest.mark.usefixtures("run_rake_task_mock")
 def test_generate_and_write_dataset(mock_input_data, mock_project_root):
-    path = generate_and_write_dataset(mock_input_data, "titan", mock_project_root)
+    path = generate_and_write_dataset(mock_input_data, mock_project_root)
     assert path.exists()
     with open(path, "r") as file:
         for line in file:

--- a/tests/topic_tagger/test_cli.py
+++ b/tests/topic_tagger/test_cli.py
@@ -11,7 +11,6 @@ def mock_config_file(tmp_path, mock_input_data):
     """Write a config file as an input for testing"""
     data = {
         "what": "Testing Topic Tagger evaluations",
-        "provider": "claude",
         "generate": True,
         "input_path": str(mock_input_data),
     }


### PR DESCRIPTION
## Description

We're removing our OpenAI integration from GOV.UK Chat. We're removing the ability to provide a provider argument to our rake tasks in this [PR](https://github.com/alphagov/govuk-chat/pull/1004).

Most of our evaluations allow provider configuration. This goes through and removed the provider/embedding provider config and related code.

We should merge this PR shortly after https://github.com/alphagov/govuk-chat/pull/1004 is merged.

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-472