### PR TITLE
[CHAT-472] Update Jailbreak Evaluation to handle serialised answer

### DIFF
--- a/govuk_chat_evaluation/jailbreak_guardrails/generate.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/generate.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import json
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -42,20 +43,26 @@ def generate_inputs_to_evaluation_results(
             env,
         )
 
-        if "success" in result:
-            return EvaluationResult(
-                question=input.question,
-                expected_outcome=input.expected_outcome,
-                actual_outcome=result["success"]["triggered"],
-                model=result["success"]["model"],
-            )
-        elif "response_error" in result:
+        jailbreak_guardrails_status = result.get("jailbreak_guardrails_status")
+
+        if jailbreak_guardrails_status == "error":
+            parsed_jailbreak_llm_response = json.loads(result["llm_responses"])[
+                "jailbreak_guardrails"
+            ]
+            invalid_llm_response = parsed_jailbreak_llm_response["content"][0]["text"]
+
             logging.warning(
-                f"Invalid response for {input.question!r}, returned: {result['response_error']!r}"
+                f"Invalid response for {input.question!r}, returned: {invalid_llm_response!r}"
             )
             return None
-        else:
-            raise RuntimeError(f"Unexpected result structure {result!r}")
+
+        actual_outcome = False if "pass" in jailbreak_guardrails_status else True
+        return EvaluationResult(
+            question=input.question,
+            expected_outcome=input.expected_outcome,
+            actual_outcome=actual_outcome,
+            model=result["metrics"]["jailbreak_guardrails"]["model"],
+        )
 
     return asyncio.run(
         generate_dataset(generate_inputs, generate_input_to_evaluation_result)

--- a/tests/jailbreak_guardrails/test_generate.py
+++ b/tests/jailbreak_guardrails/test_generate.py
@@ -17,7 +17,10 @@ def run_rake_task_mock(mocker):
     return mocker.patch(
         "govuk_chat_evaluation.jailbreak_guardrails.generate.run_rake_task",
         new_callable=AsyncMock,
-        return_value={"success": {"triggered": True, "model": "model_name"}},
+        return_value={
+            "jailbreak_guardrails_status": "pass",
+            "metrics": {"jailbreak_guardrails": {"model": "model_name"}},
+        },
     )
 
 
@@ -26,9 +29,15 @@ def test_generate_models_to_evaluation_results_returns_evaluation_results(
 ):
     def result_per_question(_, env):
         if env["INPUT"] == "Question 1":
-            return {"success": {"triggered": True, "model": "model_name"}}
+            return {
+                "jailbreak_guardrails_status": "fail",
+                "metrics": {"jailbreak_guardrails": {"model": "model_name"}},
+            }
         else:
-            return {"success": {"triggered": False, "model": "model_name"}}
+            return {
+                "jailbreak_guardrails_status": "pass",
+                "metrics": {"jailbreak_guardrails": {"model": "model_name"}},
+            }
 
     run_rake_task_mock.side_effect = result_per_question
     generate_inputs = [
@@ -61,35 +70,20 @@ def test_generate_models_to_evaluation_results_copes_with_response_errors(
 ):
     caplog.set_level(logging.WARNING)
     run_rake_task_mock.return_value = {
-        "response_error": {"message": "Error", "llm_guardrail_result": "Huh?"}
+        "jailbreak_guardrails_status": "error",
+        "llm_responses": json.dumps(
+            {"jailbreak_guardrails": {"content": [{"text": "Huh?"}]}}
+        ),
     }
     generate_inputs = [
         GenerateInput(question="Question 1", expected_outcome=True),
     ]
     actual_results = generate_inputs_to_evaluation_results(None, generate_inputs)
 
-    log_message = (
-        "Invalid response for 'Question 1', returned: "
-        "{'message': 'Error', 'llm_guardrail_result': 'Huh?'}"
-    )
+    log_message = "Invalid response for 'Question 1', returned: 'Huh?'"
 
     assert actual_results == []
     assert log_message in caplog.text
-
-
-def test_generate_models_to_evaluation_results_raises_on_unexpected_key(
-    run_rake_task_mock,
-):
-    run_rake_task_mock.return_value = {"what": {"triggered": True}}
-    generate_inputs = [
-        GenerateInput(question="Question 1", expected_outcome=True),
-    ]
-    with pytest.raises(RuntimeError) as exc_info:
-        generate_inputs_to_evaluation_results(None, generate_inputs)
-
-    assert "Unexpected result structure {'what': {'triggered': True}}" in str(
-        exc_info.value
-    )
 
 
 def test_generate_models_to_evaluation_models_runs_expected_rake_task(


### PR DESCRIPTION
## Description

We've recently changed the jailbreak guardrails implementation in Chat by combining the various Jailbreak Guardrails classes into the one class in the pipeline.

This means that the rake task now runs the pipeline with the jailbreak guardrails and and returns an answer instead of a Result object with various attributes.

While we could re-create the dict that was passed to back it makes more sense to bring the jailbreak guardrails rake task inline with the other evaluation rake tasks by returning a serialised answer and allowing the evaluation repo to use what it needs from the answer to create the evaluation results.

This updates the `generate_inputs_to_evaluation_results` function to grab the `jailbreak_guardrails_status` and model from the serialised answer.

When an error occured during generation it logs a warning as it did before. It parses the `llm_responses` and digs into `jailbreak_guardrails` llm response for the invalid response. It then excludes the input from the evaluation results.

If jailbreak_guardrails_status is `"pass"` or `"fail"` it generates the actual_outcome by mapping `"pass"` to `False` and `"fail"` to `True` so no other changes are required.

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-472