### PR TITLE
[CHAT-472] Update output guardrails to handle serialised answer

### DIFF
--- a/govuk_chat_evaluation/output_guardrails/generate.py
+++ b/govuk_chat_evaluation/output_guardrails/generate.py
@@ -46,13 +46,18 @@ def generate_inputs_to_evaluation_results(
             env,
         )
 
+        triggered_guardrails = result[f"{guardrail_type}_failures"]
+        actual_guardrails = {}
+        for guardrail in input.expected_guardrails.keys():
+            actual_guardrails[guardrail] = guardrail in triggered_guardrails
+
         return EvaluationResult(
             question=input.question,
             expected_triggered=input.expected_triggered,
-            actual_triggered=result["triggered"],
+            actual_triggered=len(triggered_guardrails) > 0,
             expected_guardrails=input.expected_guardrails,
-            actual_guardrails=result["guardrails"],
-            model=result["model"],
+            actual_guardrails=actual_guardrails,
+            model=result["metrics"][guardrail_type]["model"],
         )
 
     return asyncio.run(

--- a/tests/output_guardrails/conftest.py
+++ b/tests/output_guardrails/conftest.py
@@ -18,7 +18,7 @@ def mock_input_data(mock_project_root):
             "question": "Question 2",
             "expected_triggered": False,
             "actual_triggered": True,
-            "expected_guardrails": {"appropriate_language": False},
+            "expected_guardrails": {"appropriate_language": False, "political": False},
             "actual_guardrails": {"appropriate_language": True, "political": True},
             "model": "model_name",
         },

--- a/tests/output_guardrails/test_evaluate.py
+++ b/tests/output_guardrails/test_evaluate.py
@@ -73,8 +73,7 @@ def result_mixed_guardrails() -> EvaluationResult:
             "g1": True,
             "g2": True,
             "g3": False,
-            "g4": True,
-        },  # g1 TP, g2 FP, g3 TN, g4 FP
+        },  # g1 TP, g2 FP, g3 TN
         model="model_name",
     )
 
@@ -102,7 +101,7 @@ class TestEvaluationResult:
             "expected_triggered": True,
             "actual_triggered": True,
             "expected_guardrails": {"g1": True, "g2": False, "g3": True},
-            "actual_guardrails": {"g1": True, "g2": True, "g3": False, "g4": True},
+            "actual_guardrails": {"g1": True, "g2": True, "g3": False},
             "model": "model_name",
             "classification": "true_positive",
         }

--- a/tests/output_guardrails/test_generate.py
+++ b/tests/output_guardrails/test_generate.py
@@ -18,22 +18,14 @@ def run_rake_task_mock(mocker):
         if env["INPUT"] == "Question 1":
             return {
                 "triggered": True,
-                "guardrails": {
-                    "appropriate_language": True,
-                    "political": True,
-                    "contains_pii": False,
-                },
-                "model": "model_name",
+                "answer_guardrails_failures": ["appropriate_language", "political"],
+                "metrics": {"answer_guardrails": {"model": "model_name"}},
             }
         else:
             return {
                 "triggered": False,
-                "guardrails": {
-                    "appropriate_language": False,
-                    "political": False,
-                    "contains_pii": False,
-                },
-                "model": "model_name",
+                "answer_guardrails_failures": [],
+                "metrics": {"answer_guardrails": {"model": "model_name"}},
             }
 
     mock = mocker.patch(
@@ -94,7 +86,6 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
             actual_guardrails={
                 "appropriate_language": False,
                 "political": False,
-                "contains_pii": False,
             },
             model="model_name",
         ),


### PR DESCRIPTION
## Description

We're now passing a serialised answer back. I've had a look at the output_guardrails.jsonl file[1] and i can see that the guardrails are always present in the expected_guardrails dict as keys with a boolean value regardless if they're True or False.

As the serialised answer stores the triggered guardrails as a list of strings, we can ensure the actual_guardrails dict has the same keys as expected_guardrails and set the value to True if the guardrail is in the list of triggered guardrails.

I've removed some values from a couple of tests where a triggered guardrail was present that wasn't in the expected guardrails as this is not possible.

The reason fo this is that since all the guardrails are always present in the expected_guardrails dict and we enforce a tool which only has these available as enum values it is unable to return a guardrail that isn't in the expected_guardrails dict.

[1]: https://github.com/alphagov/govuk-chat-groundtruth-datasets/blob/main/components/output_guardrail/jsonl/v2.0/dataset.jsonl

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-472