### PR TITLE
increases maxtokens for gpt-oss to match govuk-chatauto-evaluation maxtokens

### DIFF
--- a/govuk_chat_evaluation/rag_answers/data_models/config.py
+++ b/govuk_chat_evaluation/rag_answers/data_models/config.py
@@ -95,7 +95,7 @@ class LLMJudgeModelConfig(BaseModel):
                     aws_session_token=os.getenv("AWS_SESSION_TOKEN"),
                     generation_kwargs={
                         "temperature": self.temperature,
-                        "maxTokens": 6000,
+                        "maxTokens": 15_000,
                     },
                 )
                 return attach_invalid_json_retry_to_model(model)


### PR DESCRIPTION
This PR updates the maxtokens parameter in rag_answers to match the number set in govuk-chat auto-evaluation to minimise the number of runs that error / are unsuccessful for coherence and context relevancy.