### PR TITLE
[CHAT-705] Update faithfulness metric to penalise ambiguous claims

### DIFF
--- a/govuk_chat_evaluation/rag_answers/data_models/config.py
+++ b/govuk_chat_evaluation/rag_answers/data_models/config.py
@@ -150,7 +150,11 @@ class TaskConfig(BaseConfig):
         model = metric.llm_judge.instantiate_llm_judge()
         match metric.name:
             case MetricName.FAITHFULNESS:
-                return FaithfulnessMetric(threshold=metric.threshold, model=model)
+                return FaithfulnessMetric(
+                    threshold=metric.threshold,
+                    model=model,
+                    penalize_ambiguous_claims=True,
+                )
             case MetricName.RELEVANCE:
                 return AnswerRelevancyMetric(threshold=metric.threshold, model=model)
             case MetricName.BIAS:


### PR DESCRIPTION
## Description

This is configurable via the `penalise_ambiguous_claims` parameter, which is set to 'False' by default.

This is also being updated in the Ruby evalation pipeline in the GOV.UK Chat repo.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev%2Cbackend_dev&selectedIssue=CHAT-705